### PR TITLE
Save timestamp on deploy and display on DS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,5 @@ imgui.ini
 
 
 # End of https://www.gitignore.io/api/c++,java,linux,macos,gradle,windows,visualstudiocode
+
+/src/main/deploy/deployTimestamp.properties

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,13 @@ deploy {
             directory = '/home/lvuser/deploy'
         }
     }
+
+    def deployTimestampFile = file('src/main/deploy/deployTimestamp.properties')
+
+    def Properties deployTimestamp = new Properties()
+    deployTimestamp['DEPLOY_TIMESTAMP'] = new Date().format('HH:mm:ss')
+    deployTimestamp.store(deployTimestampFile.newWriter(), null)
+    logger.info('Writing deploy timestamp')
 }
 
 def includeDesktopSupport = false

--- a/src/main/java/com/pigmice/frc/robot/Robot.java
+++ b/src/main/java/com/pigmice/frc/robot/Robot.java
@@ -1,7 +1,10 @@
 package com.pigmice.frc.robot;
 
+import java.io.FileInputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 import com.kauailabs.navx.frc.AHRS;
@@ -17,6 +20,7 @@ import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
 import edu.wpi.first.wpilibj.DoubleSolenoid;
+import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.SPI;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -48,8 +52,6 @@ public class Robot extends TimedRobot {
         subsystems.forEach((ISubsystem subsystem) -> subsystem.initialize());
 
         autonomous = new Test(drivetrain, shooter, feeder, intake);
-
-        SmartDashboard.putString("Build", "0");
     }
 
     @Override
@@ -108,6 +110,22 @@ public class Robot extends TimedRobot {
     public void disabledPeriodic() {
         subsystems.forEach((ISubsystem subsystem) -> subsystem.updateInputs());
         subsystems.forEach((ISubsystem subsystem) -> subsystem.updateDashboard());
+    }
+
+    public void displayDeployTimestamp() {
+        FileInputStream file;
+        Properties properties = new Properties();
+
+        try {
+            Path filePath = Filesystem.getDeployDirectory().toPath().resolve("/deployTimestamp.properties");
+            file = new FileInputStream(filePath.toFile());
+            properties.load(file);
+        } catch(Exception e) {
+            SmartDashboard.putString("Deploy Timestamp", "none");
+            return;
+        }
+
+        SmartDashboard.putString("Deploy Timestamp", properties.getProperty("DEPLOY_TIMESTAMP"));
     }
 
     public Drivetrain setupDrivetrain() {


### PR DESCRIPTION
Sometimes gradle will not deploy, by storing the deploy timestamp and displaying it on the driver station will make it easy to tell if a code deploy made it onto the robot.